### PR TITLE
메인 페이지 스토리북 적용 및 view 파일 분리

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,6 @@
+import React from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -6,4 +9,14 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};
+
+export const decorators = [
+  (Story) => (
+    <BrowserRouter>
+      <Routes>
+        <Route path="*" element={Story()} />
+      </Routes>
+    </BrowserRouter>
+  ),
+];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,17 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient();
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/pages/MainMap/MainMap.tsx
+++ b/src/pages/MainMap/MainMap.tsx
@@ -1,28 +1,22 @@
 import React from "react";
 import { useQuery } from "react-query";
-import { useNavigate } from "react-router-dom";
 import { getCapsuleInfo } from "../../api/capsule";
 import MainMapView from "./MainMap.view";
 
 const MainMap = () => {
-  const navigate = useNavigate();
-
   const { isLoading, data, isError } = useQuery("getCapsuleInfo", () =>
     getCapsuleInfo()
   );
 
-  return (
-    <div>
-      <button
-        onClick={() => {
-          navigate("/main/sea");
-        }}
-      >
-        바다로 가기
-      </button>
-      <MainMapView days={data ? "" : ""} />
-    </div>
-  );
+  if (isLoading) {
+    return <>로딩중입니다...</>;
+  }
+
+  if (isError) {
+    return <>에러가 발생했습니다. 다시 시도해주세요.</>;
+  }
+
+  return <MainMapView days={data ? "" : ""} />;
 };
 
 export default MainMap;

--- a/src/pages/MainMap/MainMap.tsx
+++ b/src/pages/MainMap/MainMap.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useQuery } from "react-query";
 import { useNavigate } from "react-router-dom";
 import { getCapsuleInfo } from "../../api/capsule";
+import MainMapView from "./MainMap.view";
 
 const MainMap = () => {
   const navigate = useNavigate();
@@ -19,7 +20,7 @@ const MainMap = () => {
       >
         바다로 가기
       </button>
-      메인 화면 - 지도
+      <MainMapView days={data ? "" : ""} />
     </div>
   );
 };

--- a/src/pages/MainMap/MainMap.view.stories.tsx
+++ b/src/pages/MainMap/MainMap.view.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from "@storybook/react";
 import MainMapView, { Props } from "./MainMap.view";
 
 export default {
-  title: "Main/Sea",
+  title: "Main/Map",
   component: MainMapView,
 } as Meta;
 

--- a/src/pages/MainMap/MainMap.view.stories.tsx
+++ b/src/pages/MainMap/MainMap.view.stories.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import MainMapView, { Props } from "./MainMap.view";
+
+export default {
+  title: "Main/Sea",
+  component: MainMapView,
+} as Meta;
+
+const Template: Story<Props> = (args) => <MainMapView {...args} />;
+
+export const 캡슐_있음 = Template.bind({});
+캡슐_있음.args = {
+  days: "10",
+};

--- a/src/pages/MainMap/MainMap.view.tsx
+++ b/src/pages/MainMap/MainMap.view.tsx
@@ -1,10 +1,21 @@
+import { useNavigate } from "react-router-dom";
+
 export interface Props {
   days: string;
 }
 
 const MainMapView = ({ days }: Props) => {
+  const navigate = useNavigate();
+
   return (
     <>
+      <button
+        onClick={() => {
+          navigate("/main/sea");
+        }}
+      >
+        바다로 가기
+      </button>
       <div>{days}일 째 여행 중</div>
     </>
   );

--- a/src/pages/MainMap/MainMap.view.tsx
+++ b/src/pages/MainMap/MainMap.view.tsx
@@ -1,0 +1,13 @@
+export interface Props {
+  days: string;
+}
+
+const MainMapView = ({ days }: Props) => {
+  return (
+    <>
+      <div>{days}일 째 여행 중</div>
+    </>
+  );
+};
+
+export default MainMapView;

--- a/src/pages/MainSea/MainSea.tsx
+++ b/src/pages/MainSea/MainSea.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { useQuery } from "react-query";
-import { useNavigate } from "react-router-dom";
 import { hasCapsule, hasUnknownCapsule } from "../../api/capsule";
+import MainSeaView from "./MainSea.view";
 
 const MainSea = () => {
-  const navigate = useNavigate();
-
   const {
     isLoading: isUnknownCapsuleLoading,
     data: unknownCapsule,
@@ -18,17 +16,20 @@ const MainSea = () => {
     isError: isCapsuleError,
   } = useQuery("hasCapsule", () => hasCapsule());
 
+  if (isUnknownCapsuleLoading || isCapsuleLoading) {
+    return <>로딩중입니다...</>;
+  }
+
+  if (isUnknownCapsuleError || isCapsuleError) {
+    return <>에러가 발생했습니다. 다시 시도해주세요.</>;
+  }
+
   return (
-    <div>
-      <button
-        onClick={() => {
-          navigate("/main/map");
-        }}
-      >
-        지도로 가기
-      </button>
-      메인 화면 - 바다
-    </div>
+    <MainSeaView
+      unknownCapsule={unknownCapsule ? "" : ""}
+      hasCapsule={capsule ? true : false}
+      showDescription
+    />
   );
 };
 

--- a/src/pages/MainSea/MainSea.view.stories.tsx
+++ b/src/pages/MainSea/MainSea.view.stories.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import MainSeaView, { Props } from "./MainSea.view";
+
+export default {
+  title: "Main/Sea",
+  component: MainSeaView,
+} as Meta<Props>;
+
+const Template: Story<Props> = (args) => <MainSeaView {...args} />;
+
+export const 익명의_캡슐_있음 = Template.bind({});
+익명의_캡슐_있음.args = {
+  unknownCapsule: "1",
+  hasCapsule: true,
+  showDescription: false,
+};
+
+export const 캡슐_없음 = Template.bind({});
+캡슐_없음.args = {
+  unknownCapsule: "",
+  hasCapsule: false,
+  showDescription: false,
+};
+
+export const 캡슐_생성_후 = Template.bind({});
+캡슐_생성_후.args = {
+  unknownCapsule: "",
+  hasCapsule: true,
+  showDescription: true,
+};

--- a/src/pages/MainSea/MainSea.view.tsx
+++ b/src/pages/MainSea/MainSea.view.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 export interface Props {
   unknownCapsule: string;
   hasCapsule: boolean;
@@ -9,13 +11,27 @@ const MainSeaView = ({
   hasCapsule,
   showDescription,
 }: Props) => {
+  const navigate = useNavigate();
+
   return (
     <>
       <button>설정</button>
       {hasCapsule ? (
-        <button>지도로 가기</button>
+        <button
+          onClick={() => {
+            navigate("/main/map");
+          }}
+        >
+          지도로 가기
+        </button>
       ) : (
-        <button>캡술 만들러 가기</button>
+        <button
+          onClick={() => {
+            navigate("/capsule/design");
+          }}
+        >
+          캡술 만들러 가기
+        </button>
       )}
       {showDescription && <div>바다 화면에서 캡슐을 다시 볼 수 있어요!</div>}
       <div>{unknownCapsule && "익명의 캡슐이 있네요. 보시겠습니까?"}</div>

--- a/src/pages/MainSea/MainSea.view.tsx
+++ b/src/pages/MainSea/MainSea.view.tsx
@@ -1,0 +1,26 @@
+export interface Props {
+  unknownCapsule: string;
+  hasCapsule: boolean;
+  showDescription: boolean;
+}
+
+const MainSeaView = ({
+  unknownCapsule,
+  hasCapsule,
+  showDescription,
+}: Props) => {
+  return (
+    <>
+      <button>설정</button>
+      {hasCapsule ? (
+        <button>지도로 가기</button>
+      ) : (
+        <button>캡술 만들러 가기</button>
+      )}
+      {showDescription && <div>바다 화면에서 캡슐을 다시 볼 수 있어요!</div>}
+      <div>{unknownCapsule && "익명의 캡슐이 있네요. 보시겠습니까?"}</div>
+    </>
+  );
+};
+
+export default MainSeaView;


### PR DESCRIPTION
## 요구사항

- 메인 화면 상황별로 보이는 케이스 스토리북 제작

## 수정내용

- 스토리북 추가 적용
- 스토리북 내 라우터 미 지원으로 decorator 적용

## 테스트

- [x] local
- [ ] test code
      (아래에 테스트 코드를 실행시킨 결과를 첨부해주세요.)
