### PR TITLE
[Feature/hyelme/create api-2] 로그인 API 및 validate 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "msw": "^0.39.2",
     "webpack": "^5.74.0"
   },
-  "proxy": "http://www.na-vi.xyz/"
+  "proxy": "http://www.na-vi.xyz:8080"
 }

--- a/src/api/user/signIn.ts
+++ b/src/api/user/signIn.ts
@@ -1,11 +1,24 @@
-import axiosInstance from "api";
 import { UserApiUrls } from "api/path";
+import axios from "axios";
+import { resultData } from "configs/axios";
 
 export type SignInBody = {
   nickname: string,
   password: string
 }
 
+export type SignInResponse = {
+  access_token: "",
+  refresh_token: ""
+}
+
 export const signIn = (data: SignInBody) => {
-  return axiosInstance.post(UserApiUrls.signin(), data);
+  console.log("로그인 정보 : ", data.nickname, ", ", data.password);
+  return resultData<SignInResponse>(
+    axios.post(UserApiUrls.signin(), data)
+  )
+  .then((res) => {
+    const accessToken = res.access_token;
+    axios.defaults.headers.common['Authorization'] = `${accessToken}`;
+  })
 }

--- a/src/components/common/inputText/InputText.tsx
+++ b/src/components/common/inputText/InputText.tsx
@@ -8,6 +8,7 @@ interface InputTxtProps extends React.HTMLProps<HTMLInputElement> {
   widthSize?: "small" | "medium" | "large";
   mode?: "normal" | "warning" | "focus";
   placeholder: string;
+  warningMsg?: string;
   onFocus?: () => void;
   onChangeValue: (val: string) => void;
 }
@@ -16,6 +17,7 @@ const InputText = ({
   type = "text",
   widthSize = "medium",
   placeholder = "placeholder",
+  warningMsg = "",
   inputId="",
   mode,
   onFocus,
@@ -38,6 +40,9 @@ const InputText = ({
         placeholder={mode !== "normal" ? "" : placeholder}
         onChange={(e) => onChangeValue(e.target.value)}
       />
+      {warningMsg !== "" && (
+        <div>{warningMsg}</div>
+      )}
     </>
   );
 };

--- a/src/configs/axios/config.ts
+++ b/src/configs/axios/config.ts
@@ -32,17 +32,20 @@ const responseOnFullFilled = async (
 ): Promise<AxiosResponse> => {
   // TODO: 토큰 새로 발급이 필요한 경우 처리 로직 케이스 추가
   // 서버에서 내려오는 응답값 확인 후 수정 예정
-  if (response.data === "SUCCESS") {
-    return { ...response, data: response.data };
-  } else {
-    throw new AxiosError(
-      response.data.error.message,
-      "", // TODO: res.data.error.code를 가지고 AxiosErrorCode로 설정
-      response.config,
-      response.request,
-      response
-    );
-  }
+  // if (response.data === "SUCCESS") {
+    // return { ...response, data: response.data };
+  // } else {
+  //   throw new Error();
+    // throw new AxiosError(
+    //   response.data.error.message,
+    //   "", // TODO: res.data.error.code를 가지고 AxiosErrorCode로 설정
+    //   response.config,
+    //   response.request,
+    //   response
+    // );
+  // }
+
+  return response;
 };
 
 /**

--- a/src/configs/axios/helpers.ts
+++ b/src/configs/axios/helpers.ts
@@ -3,15 +3,11 @@ import axios, { AxiosPromise } from "axios";
 export const isAxiosError = axios.isAxiosError;
 
 export const resultData = async <T = any>(
-  promiseObject: AxiosPromise<{
-    data: T;
-    result: "SUCCESS" | "ERROR";
-    error: { code: string; message: string; data: any };
-  }>
+  promiseObject: AxiosPromise<T>
 ): Promise<T> => {
   try {
     const result = await promiseObject;
-    return result.data.data;
+    return result.data;
   } catch (error) {
     throw error;
   }

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,16 +1,38 @@
+import { signIn } from "api/user";
+import { useNavigate } from "react-router-dom";
 import SignInView from "./SignIn.view";
 
-export type SignInForm = {nickname: string, password: string};
+export type SignInForm = {
+  nickname: string, 
+  password: string
+};
+
+export type SignInError = {
+  message: string,
+  code: string,
+  status: number
+}
 
 const SignIn = () => {
+  const navigate = useNavigate();  
 
   const clickSubmit = (data: SignInForm) => {
     //TODO: 클릭 이벤트 적용하기
-    console.log("로그인 테스트");
-    console.log("email : ", data.nickname);
-    console.log("password: ", data.password);
+    // console.log("로그인 테스트");
+    // console.log("email : ", data.nickname);
+    // console.log("password: ", data.password);
+
+    signIn(data)
+    .then((res) => {
+      navigate(`/main/sea`);
+    })
+    .catch((err:SignInError) => {
+      //TODO: error 처리 로직 구현
+      // console.log("err : ", err);
+      return <>에러가 발생했습니다. 다시 시도해주세요.</>
+    })
   }
-  
+
   //TODO: isLoggedIn 값 변경 필요
   return <SignInView isLoggedIn ={true} clickSubmit={clickSubmit}/>
 };

--- a/src/pages/SignIn/SignIn.view.tsx
+++ b/src/pages/SignIn/SignIn.view.tsx
@@ -14,6 +14,11 @@ export interface Props {
   clickSubmit: (data: SignInForm) => void;
 }
 
+export type SignInValidation = {
+  nicknameValidation: boolean;
+  passwordValidation: boolean;
+}
+
 const SignInView = ({ isLoggedIn = true, clickSubmit }: Props) => {
   const navigate = useNavigate();
 
@@ -24,19 +29,40 @@ const SignInView = ({ isLoggedIn = true, clickSubmit }: Props) => {
     nickname: "",
     password: "",
   });
-
-  const handleButtonEvent = () => {
-    clickSubmit(stateValues);
-  };
+  const [warningMsg, setWarningMsg] = useState<string>("");
+  const [inputValidation, setInputValidation] = useState<SignInValidation>({
+    nicknameValidation: false,
+    passwordValidation: false
+  });
+  const [buttonStatus, setButtonStatus] = useState<boolean>(true);
 
   useEffect(() => {
     setModeValue(isLoggedIn ? "normal" : "warning");
   }, [isLoggedIn]);
 
+  useEffect(() => {
+    setButtonStatus((inputValidation.nicknameValidation && inputValidation.passwordValidation)? false:true)
+    console.log(buttonStatus);
+  }, [inputValidation]);
+
+  const nicknameValid = (data:string) => {
+    // 최소 2 ~ 최대 10자 이하
+    const regex = /^.{2,10}$/;
+    return regex.test(data);
+  }
+  const passwordValid = (data:string) => {
+    // 영문, 숫자, 특수기호 포함 8~30자 이하
+    const regex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,30}$/;
+    return regex.test(data);
+  }
+  const handleButtonEvent = () => {
+    clickSubmit(stateValues);
+  };
+
   return (
     <InputForm
       submitButtonText="로그인"
-      disabledSubmitButton={true}
+      disabledSubmitButton={buttonStatus}
       onSubmit={handleButtonEvent}
     >
       <div className="signIn-wrap">
@@ -56,8 +82,19 @@ const SignInView = ({ isLoggedIn = true, clickSubmit }: Props) => {
               mode={modeValue}
               widthSize="medium"
               placeholder="닉네임"
-              onChangeValue={(value: string) =>
+              warningMsg={modeValue === "warning" && (warningMsg !== "" || !inputValidation.nicknameValidation)? warningMsg : ""}
+              onChangeValue={(value: string) => {
+                //TODO: 닉네임 중복체크 로직 구현
+                setInputValidation({...inputValidation, nicknameValidation: nicknameValid(value)});
+                if(!nicknameValid(value)) {
+                  setModeValue("warning");
+                  setWarningMsg("닉네임은 최소 2자 ~ 최대 10자 이내로 작성해주세요.");
+                }else {
+                  setModeValue("focus");
+                  setWarningMsg("");
+                }
                 setStateValues({ ...stateValues, nickname: value })
+              }
               }
             />
             <InputText
@@ -66,8 +103,19 @@ const SignInView = ({ isLoggedIn = true, clickSubmit }: Props) => {
               mode={modeValue}
               widthSize="medium"
               placeholder="비밀번호"
-              onChangeValue={(value: string) =>
+              warningMsg={modeValue === "warning" && ((warningMsg !== "" || !inputValidation.passwordValidation))? warningMsg : ""}
+              onChangeValue={(value: string) =>{
+                setInputValidation({...inputValidation, passwordValidation: passwordValid(value)});
+                if(!passwordValid(value)) {
+                  setModeValue("warning");
+                  setWarningMsg("비밀번호는 영문/숫자/특수기호를 포함하여 최소 8자 ~ 30자 이내로 작성해주세요.");
+                }else {
+                  setModeValue("focus");
+                  setWarningMsg("");
+                }
                 setStateValues({ ...stateValues, password: value })
+              }
+                
               }
             />
           </div>

--- a/src/pages/SignIn/hook/useSignIn.tsx
+++ b/src/pages/SignIn/hook/useSignIn.tsx
@@ -1,0 +1,22 @@
+import { SignInBody } from "api/user";
+// import useSignInQuery from "queries/user/useSignInQuery";
+
+// const useSignIn = (data: SignInBody) => {
+//   const {
+//     isLoading: isSignInLoading,
+//     data: signIn,
+//     isError: isSignInError,
+//     mutate
+//   } = useSignInQuery(data);
+
+//   return {
+//     isLoading: isSignInLoading,
+//     data: signIn,
+//     isError: isSignInError,
+//     mutate,
+//     //TODO: isJoined 어케 판단할지 수정 필요
+//     isLoggedIn: isSignInError ? true : false
+//   };
+// };
+
+// export default useSignIn;

--- a/src/queries/user/useSignInQuery.ts
+++ b/src/queries/user/useSignInQuery.ts
@@ -1,0 +1,21 @@
+import { signIn, SignInBody, SignInResponse } from "api/user";
+import { useMutation, UseMutationOptions } from "react-query";
+
+// const useSignInQuery = (
+//   data: SignInBody,
+//   options?: UseMutationOptions<SignInResponse>
+//   ) => {
+//     console.log("useSignInQuery : ", data.nickname, ", ", data.password)
+//     const response = useMutation<SignInResponse>(
+//       "signIn",
+//       () => signIn(data),
+//       {
+//         ...options
+//       });
+
+//     console.log("signIn res : ", response);
+    
+//     return response;
+//   }
+
+// export default useSignInQuery;


### PR DESCRIPTION
- 로그인 API 적용(이후 API에 Authorization 헤더 적용 확인)
- 로그인 화면 inputBox validate 적용

|설명|이미지|
|---|---|
|로그인 API|![image](https://user-images.githubusercontent.com/40186789/208291062-92ccdb96-d723-435f-811d-5931492a8279.png)|
|inputBox validate|![image](https://user-images.githubusercontent.com/40186789/208291115-7bf3f909-2146-4d64-8a2a-a41f92998746.png)|


###TODO
- inputBox param 한 번에 적용되는 기능들 분리하기
- api error catch 로직 구현하기