### PR TITLE
[Feature/hyelme/create-api-3] inputbox valid 체크 분리 및 에러 catch 구현

### DIFF
--- a/src/configs/axios/config.ts
+++ b/src/configs/axios/config.ts
@@ -1,9 +1,13 @@
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 type ErrorResponse = {
-  errorCode: string;
-  errorMessage?: string;
-  code: string;
+  // errorCode: string;
+  // errorMessage?: string;
+  // code: string;
+
+  message: string,
+  code: string,
+  status: number
 };
 
 /**
@@ -59,9 +63,11 @@ const responseOnRejected = async (
   error: AxiosError
 ): Promise<AxiosError<ErrorResponse>> => {
   return new Promise((_, reject) => {
-    const { code } = error;
+    const { code, response } = error;
+    const data: ErrorResponse = response?.data as unknown as ErrorResponse;
 
     if (code) {
+      if(data !== null && data.code !== undefined) reject(data); 
       switch (code) {
         case "ERR_BAD_REQUEST":
         case "INVALID_REQUEST":

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,6 +1,9 @@
 import { signIn } from "api/user";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import SignInView from "./SignIn.view";
+
+import { HTTP_STATUS } from "configs/axios";
 
 export type SignInForm = {
   nickname: string, 
@@ -15,26 +18,21 @@ export type SignInError = {
 
 const SignIn = () => {
   const navigate = useNavigate();  
-
+  
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
+  
   const clickSubmit = (data: SignInForm) => {
-    //TODO: 클릭 이벤트 적용하기
-    // console.log("로그인 테스트");
-    // console.log("email : ", data.nickname);
-    // console.log("password: ", data.password);
-
     signIn(data)
     .then((res) => {
       navigate(`/main/sea`);
     })
     .catch((err:SignInError) => {
-      //TODO: error 처리 로직 구현
-      // console.log("err : ", err);
-      return <>에러가 발생했습니다. 다시 시도해주세요.</>
+      setIsLoggedIn(false);
+      if(err.status === (HTTP_STATUS.NOT_FOUND || HTTP_STATUS.UNAUTHORIZED)) alert("닉네임 또는 비밀번호가 일치하지 않습니다. 로그인 정보를 다시 확인해주세요.")
     })
   }
 
-  //TODO: isLoggedIn 값 변경 필요
-  return <SignInView isLoggedIn ={true} clickSubmit={clickSubmit}/>
+  return <SignInView isLoggedIn ={isLoggedIn} clickSubmit={clickSubmit}/>
 };
 
 export default SignIn;

--- a/src/pages/SignIn/type/SignInType.ts
+++ b/src/pages/SignIn/type/SignInType.ts
@@ -1,0 +1,5 @@
+export type InputState = {
+  state: "normal" | "focus" | "warning";
+  validation: boolean;
+  warningMsg: string;
+}


### PR DESCRIPTION
|설명|이미지|
|---|---|
|valid 체크 분리|![image](https://user-images.githubusercontent.com/40186789/209427881-dc5a8e62-50a9-4eee-9850-e14768411197.png)|
|error catch 구현|![image](https://user-images.githubusercontent.com/40186789/209427908-ff74e3b8-9708-4645-81fc-21e174c7ca1c.png)|

- inputbox(닉네임, 비밀번호) valid 체크 분리
- 에러 캐치 로직 구현
- reject 코드 수정
  - as-is : 서버 에러랑 global 에러가 같은 코드로 넘어와서 reject로 에러 메세지만 넘겨줘서 error response data에 접근 불가
  - to-be: error response data가 넘어온 경우, 해당 데이터를 넘겨주는 방식으로 변경(검증 필요)